### PR TITLE
fix(auth): bypass Next.js rewrite for login/logout

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  env: {
+    // Backend auth origin. The auth flow (login, logout) bypasses the
+    // /api/* rewrite so that Set-Cookie's Domain attribute is set against
+    // the actual response origin (api.mdrive.mandacode.com), not the SPA
+    // domain. Override per environment in .env.production if needed.
+    NEXT_PUBLIC_AUTH_BASE: "https://api.mdrive.mandacode.com",
+  },
   async rewrites() {
     // Skip rewrites in development to allow MSW to intercept requests
     if (process.env.NODE_ENV === "development") {

--- a/src/api/hooks/use-auth.ts
+++ b/src/api/hooks/use-auth.ts
@@ -1,14 +1,29 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 import type { User } from "@/api/generated/model";
 import {
-  getAuthLoginUrl,
-  getAuthLogoutMutationOptions,
   getAuthMeQueryOptions,
   getCreateDriveMutationOptions,
-  getDeleteDriveMutationOptions,
   getListDrivesQueryOptions,
+  getDeleteDriveMutationOptions,
   getRestoreDriveMutationOptions,
 } from "@/api/generated";
+
+/**
+ * Backend auth URL. In production we hit the API origin directly so the
+ * auth cookies (state, session) are set against the response's own origin —
+ * proxying the Set-Cookie through the Next.js rewrite would attribute the
+ * cookie to `mdrive.mandacode.com` and trip the browser's domain check.
+ *
+ * Set NEXT_PUBLIC_AUTH_BASE in `.env.production` (e.g.
+ * `https://api.mdrive.mandacode.com`). In dev it is empty so the path stays
+ * relative and MSW intercepts it.
+ */
+function authUrl(path: string): string {
+  const base = process.env.NEXT_PUBLIC_AUTH_BASE ?? "";
+  if (!base) return `/api${path}`;
+  return `${base}${path}`;
+}
 
 export function useMe() {
   return useQuery({
@@ -62,28 +77,26 @@ export function useRestoreDrive() {
 }
 
 /**
- * Triggers the backend Zitadel login flow. The browser is redirected to
- * `/api/auth/login`, which Next.js rewrites to the backend in production.
- * The backend's AuthPassthrough middleware then handles the Zitadel OIDC
- * choreography and redirects back with the session cookie set.
+ * Triggers the backend Zitadel login flow. Top-level GET navigation
+ * (so SameSite=Lax cookies travel across the OAuth redirect chain).
  */
 export function login() {
-  window.location.href = getAuthLoginUrl();
+  window.location.href = authUrl("/auth/login");
 }
 
 /**
- * Calls the backend `/auth/logout` endpoint, clears the local query cache,
- * and reloads. The backend removes the `mdrive_session` cookie as part of
- * the response.
+ * Submits a POST to the backend's `/auth/logout` via a hidden form so the
+ * cookie clearing and 302 redirect to the post-logout URL all happen in one
+ * top-level navigation. No fetch + JSON dance — that would lose cookies
+ * with the proxy in the middle.
  */
 export function useLogout() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    ...getAuthLogoutMutationOptions(),
-    onSuccess: () => {
-      queryClient.removeQueries();
-      window.location.reload();
-    },
-  });
+  return useCallback(() => {
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = authUrl("/auth/logout");
+    form.style.display = "none";
+    document.body.appendChild(form);
+    form.submit();
+  }, []);
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { useEffect } from "react";
-import { getAuthLoginUrl } from "@/api/generated";
 
-// Sends the browser to the backend's OIDC login entry point. The backend's
-// AuthPassthrough middleware then runs the Zitadel choreography and
-// redirects back with the session cookie.
+const AUTH_BASE = process.env.NEXT_PUBLIC_AUTH_BASE ?? "";
+
+function authUrl(path: string): string {
+  if (!AUTH_BASE) return `/api${path}`;
+  return `${AUTH_BASE}${path}`;
+}
+
 export default function LoginPage() {
   useEffect(() => {
-    window.location.href = getAuthLoginUrl();
+    window.location.href = authUrl("/auth/login");
   }, []);
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ export default function SystemSelectionPage() {
 
   const listDrivesQuery = useDrives(isAuthenticated);
   const createDriveMutation = useCreateDrive();
-  const logoutMutation = useLogout();
+  const logout = useLogout();
 
   useEffect(() => {
     if (createDriveMutation.isSuccess) {
@@ -54,7 +54,7 @@ export default function SystemSelectionPage() {
   };
 
   const handleTurnOffClick = () => {
-    if (isAuthenticated) logoutMutation.mutate();
+    if (isAuthenticated) logout();
     else login();
   };
 
@@ -233,7 +233,6 @@ export default function SystemSelectionPage() {
           className={styles.power_button}
           onClick={handleTurnOffClick}
           type="button"
-          disabled={logoutMutation.isPending}
           aria-label={isAuthenticated ? "Log out" : "Log in"}
         >
           <svg
@@ -245,13 +244,7 @@ export default function SystemSelectionPage() {
             <title>Power</title>
             <path d="M13 3h-2v10h2V3zm4.83 2.17l-1.42 1.42C17.99 7.86 19 9.81 19 12c0 3.87-3.13 7-7 7s-7-3.13-7-7c0-2.19 1.01-4.14 2.58-5.42L6.17 5.17C4.23 6.82 3 9.26 3 12c0 4.97 4.03 9 9 9s9-4.03 9-9c0-2.74-1.23-5.18-3.17-6.83z" />
           </svg>
-          <span>
-            {logoutMutation.isPending
-              ? "Logging out..."
-              : isAuthenticated
-                ? "Log out"
-                : "Log in"}
-          </span>
+          <span>{isAuthenticated ? "Log out" : "Log in"}</span>
         </button>
         <span className={styles.bottom_hint}>
           {!isAuthenticated


### PR DESCRIPTION
## Problem

In production, OAuth login fails: `/auth/callback` returns 401
"named cookie not present". The state cookie set by zitadel-go at
`/auth/login` never reaches the browser, so the callback handler
cannot validate it.

## Root cause

Next.js rewrite proxies `/api/*` → `https://api.mdrive.mandacode.com/*`.
The browser sees the `/auth/login` response as coming from
`mdrive.mandacode.com`. zitadel-go's state cookie is set host-only
(`Domain=api.mdrive.mandacode.com`); the browser rejects a
Set-Cookie whose Domain does not match the response origin.

(Note: the chart's own `cookie.domain: .mdrive.mandacode.com` config
applies only to the session cookie zitadel-go emits at callback time,
not to the state cookie.)

## Fix

Auth flows navigate **directly** to the API origin so Set-Cookie's
Domain is set against the actual response origin. The data API
(`/api/v1/*`) keeps using the rewrite — that side is same-origin
and cookies flow naturally.

| | Before | After |
|---|---|---|
| `/auth/login` | `/api/auth/login` (rewrite) | `https://api.mdrive.mandacode.com/auth/login` (direct) |
| `/auth/logout` | React Query mutation POST | hidden form POST to absolute URL |
| `/api/v1/*` | rewrite | unchanged |

Top-level GET (login) and form POST (logout) don't trigger CORS
preflight, so no CORS configuration is needed.

## Files

- `src/api/hooks/use-auth.ts`
  - New `authUrl(path)` helper: `NEXT_PUBLIC_AUTH_BASE` if set,
    else `/api` (dev → MSW intercepts).
  - `login()`: top-level GET to `authUrl("/auth/login")`.
  - `useLogout()`: returns a callback that submits a hidden POST
    form. The backend's 302 to `post_logout_url` handles the
    redirect; no manual cache clearing needed.
- `src/app/login/page.tsx`: redirects via `authUrl`.
- `src/app/page.tsx`: `useLogout` now returns a plain callback;
    removed the obsolete `isPending` disabled/label branches.
- `next.config.mjs`: `env.NEXT_PUBLIC_AUTH_BASE =
  "https://api.mdrive.mandacode.com"` so the value is inlined at
    build time.

## Backend-side follow-up (separate PR)

For the **session** cookie (not state) to flow through the data API
rewrite, zitadel-go should set it with `Domain=.mdrive.mandacode.com`
(parent). Currently the session cookie is host-only, so on
`mdrive.mandacode.com` → api it may be dropped depending on the
browser. This is a backend-chart change and out of scope here.

## Verification

```bash
npm run lint      # 58 files clean
npx tsc --noEmit  # clean
npm run build     # NEXT_PUBLIC_AUTH_BASE inlined into bundle
```

After backend merges its `Domain=.mdrive.mandacode.com` change, in
production:
1. `/auth/login` response: `Set-Cookie: state=...; Domain=.mdrive.mandacode.com; SameSite=Lax; HttpOnly; Secure`
2. Application > Cookies > `mandacode.com`: state cookie present
3. `/auth/callback?code&state` request: `Cookie: state=...`
4. `/auth/me`: 200