### PR TITLE
refactor(api): hardcode API base + remove env var complexity

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
-  env: {
-    NEXT_PUBLIC_API_BASE: "https://api.mdrive.mandacode.com",
+  async rewrites() {
+    if (process.env.NODE_ENV === "development") {
+      return [];
+    }
+    return [];
   },
 };
 

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "orval";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
+const API_BASE = "https://api.mdrive.mandacode.com";
 
 export default defineConfig({
   api: {

--- a/src/api/generated/index.ts
+++ b/src/api/generated/index.ts
@@ -110,7 +110,7 @@ export const getHealthUrl = () => {
 
 
 
-  return `/health`
+  return `https://api.mdrive.mandacode.com/health`
 }
 
 /**
@@ -141,7 +141,7 @@ export const health = async ( options?: RequestInit): Promise<healthResponse> =>
 
 export const getHealthQueryKey = () => {
     return [
-    `/health`
+    `https://api.mdrive.mandacode.com/health`
     ] as const;
     }
 
@@ -258,7 +258,7 @@ export const getCreateDriveUrl = () => {
 
 
 
-  return `/v1/drives`
+  return `https://api.mdrive.mandacode.com/v1/drives`
 }
 
 /**
@@ -360,7 +360,7 @@ export const getListDrivesUrl = () => {
 
 
 
-  return `/v1/drives`
+  return `https://api.mdrive.mandacode.com/v1/drives`
 }
 
 /**
@@ -391,7 +391,7 @@ export const listDrives = async ( options?: RequestInit): Promise<listDrivesResp
 
 export const getListDrivesQueryKey = () => {
     return [
-    `/v1/drives`
+    `https://api.mdrive.mandacode.com/v1/drives`
     ] as const;
     }
 
@@ -503,7 +503,7 @@ export const getGetDriveUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/root`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/root`
 }
 
 /**
@@ -534,7 +534,7 @@ export const getDrive = async (driveID: string, options?: RequestInit): Promise<
 
 export const getGetDriveQueryKey = (driveID: string,) => {
     return [
-    `/v1/drives/${driveID}/root`
+    `https://api.mdrive.mandacode.com/v1/drives/${driveID}/root`
     ] as const;
     }
 
@@ -651,7 +651,7 @@ export const getUpdateDriveUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/root`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/root`
 }
 
 /**
@@ -769,7 +769,7 @@ export const getDeleteDriveUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/root`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/root`
 }
 
 /**
@@ -886,7 +886,7 @@ export const getRestoreDriveUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/restore`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/restore`
 }
 
 /**
@@ -993,7 +993,7 @@ export const getListDeletedDrivesUrl = () => {
 
 
 
-  return `/v1/admin/drives/deleted`
+  return `https://api.mdrive.mandacode.com/v1/admin/drives/deleted`
 }
 
 /**
@@ -1024,7 +1024,7 @@ export const listDeletedDrives = async ( options?: RequestInit): Promise<listDel
 
 export const getListDeletedDrivesQueryKey = () => {
     return [
-    `/v1/admin/drives/deleted`
+    `https://api.mdrive.mandacode.com/v1/admin/drives/deleted`
     ] as const;
     }
 
@@ -1136,7 +1136,7 @@ export const getGetDriveStorageUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/storage`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/storage`
 }
 
 /**
@@ -1167,7 +1167,7 @@ export const getDriveStorage = async (driveID: string, options?: RequestInit): P
 
 export const getGetDriveStorageQueryKey = (driveID: string,) => {
     return [
-    `/v1/drives/${driveID}/storage`
+    `https://api.mdrive.mandacode.com/v1/drives/${driveID}/storage`
     ] as const;
     }
 
@@ -1294,7 +1294,7 @@ export const getMkdirUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/fs/mkdir`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/mkdir`
 }
 
 /**
@@ -1422,7 +1422,7 @@ export const getTouchUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/fs/touch`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/touch`
 }
 
 /**
@@ -1550,7 +1550,7 @@ export const getRmUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/fs`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs`
 }
 
 /**
@@ -1678,7 +1678,7 @@ export const getMvUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/fs/mv`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/mv`
 }
 
 /**
@@ -1809,7 +1809,7 @@ export const getLsUrl = (driveID: string,
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/v1/drives/${driveID}/fs/ls?${stringifiedParams}` : `/v1/drives/${driveID}/fs/ls`
+  return stringifiedParams.length > 0 ? `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/ls?${stringifiedParams}` : `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/ls`
 }
 
 /**
@@ -1842,7 +1842,7 @@ export const ls = async (driveID: string,
 export const getLsQueryKey = (driveID: string,
     params?: LsParams,) => {
     return [
-    `/v1/drives/${driveID}/fs/ls`, ...(params ? [params] : [])
+    `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/ls`, ...(params ? [params] : [])
     ] as const;
     }
 
@@ -1977,7 +1977,7 @@ export const getCatUrl = (driveID: string,
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/v1/drives/${driveID}/fs/cat?${stringifiedParams}` : `/v1/drives/${driveID}/fs/cat`
+  return stringifiedParams.length > 0 ? `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/cat?${stringifiedParams}` : `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/cat`
 }
 
 /**
@@ -2010,7 +2010,7 @@ export const cat = async (driveID: string,
 export const getCatQueryKey = (driveID: string,
     params?: CatParams,) => {
     return [
-    `/v1/drives/${driveID}/fs/cat`, ...(params ? [params] : [])
+    `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/cat`, ...(params ? [params] : [])
     ] as const;
     }
 
@@ -2142,7 +2142,7 @@ export const getWriteUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/fs/write`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/write`
 }
 
 /**
@@ -2270,7 +2270,7 @@ export const getSymlinkUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/fs/symlink`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/symlink`
 }
 
 /**
@@ -2398,7 +2398,7 @@ export const getHardlinkUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/fs/hardlink`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/hardlink`
 }
 
 /**
@@ -2526,7 +2526,7 @@ export const getMountUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/fs/mount`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/mount`
 }
 
 /**
@@ -2662,7 +2662,7 @@ export const getUnmountUrl = (driveID: string,
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/v1/drives/${driveID}/fs/unmount?${stringifiedParams}` : `/v1/drives/${driveID}/fs/unmount`
+  return stringifiedParams.length > 0 ? `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/unmount?${stringifiedParams}` : `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/unmount`
 }
 
 /**
@@ -2793,7 +2793,7 @@ export const getStatUrl = (driveID: string,
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/v1/drives/${driveID}/fs/stat?${stringifiedParams}` : `/v1/drives/${driveID}/fs/stat`
+  return stringifiedParams.length > 0 ? `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/stat?${stringifiedParams}` : `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/stat`
 }
 
 /**
@@ -2826,7 +2826,7 @@ export const stat = async (driveID: string,
 export const getStatQueryKey = (driveID: string,
     params?: StatParams,) => {
     return [
-    `/v1/drives/${driveID}/fs/stat`, ...(params ? [params] : [])
+    `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/stat`, ...(params ? [params] : [])
     ] as const;
     }
 
@@ -2961,7 +2961,7 @@ export const getLstatUrl = (driveID: string,
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/v1/drives/${driveID}/fs/lstat?${stringifiedParams}` : `/v1/drives/${driveID}/fs/lstat`
+  return stringifiedParams.length > 0 ? `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/lstat?${stringifiedParams}` : `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/lstat`
 }
 
 /**
@@ -2994,7 +2994,7 @@ export const lstat = async (driveID: string,
 export const getLstatQueryKey = (driveID: string,
     params?: LstatParams,) => {
     return [
-    `/v1/drives/${driveID}/fs/lstat`, ...(params ? [params] : [])
+    `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/lstat`, ...(params ? [params] : [])
     ] as const;
     }
 
@@ -3129,7 +3129,7 @@ export const getReadlinkUrl = (driveID: string,
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/v1/drives/${driveID}/fs/readlink?${stringifiedParams}` : `/v1/drives/${driveID}/fs/readlink`
+  return stringifiedParams.length > 0 ? `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/readlink?${stringifiedParams}` : `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/readlink`
 }
 
 /**
@@ -3162,7 +3162,7 @@ export const readlink = async (driveID: string,
 export const getReadlinkQueryKey = (driveID: string,
     params?: ReadlinkParams,) => {
     return [
-    `/v1/drives/${driveID}/fs/readlink`, ...(params ? [params] : [])
+    `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/readlink`, ...(params ? [params] : [])
     ] as const;
     }
 
@@ -3297,7 +3297,7 @@ export const getRealpathUrl = (driveID: string,
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/v1/drives/${driveID}/fs/realpath?${stringifiedParams}` : `/v1/drives/${driveID}/fs/realpath`
+  return stringifiedParams.length > 0 ? `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/realpath?${stringifiedParams}` : `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/realpath`
 }
 
 /**
@@ -3330,7 +3330,7 @@ export const realpath = async (driveID: string,
 export const getRealpathQueryKey = (driveID: string,
     params?: RealpathParams,) => {
     return [
-    `/v1/drives/${driveID}/fs/realpath`, ...(params ? [params] : [])
+    `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/realpath`, ...(params ? [params] : [])
     ] as const;
     }
 
@@ -3462,7 +3462,7 @@ export const getWriteLargeUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/fs/object`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/fs/object`
 }
 
 /**
@@ -3580,7 +3580,7 @@ export const getInitiateUploadUrl = (driveID: string,) => {
 
 
 
-  return `/v1/drives/${driveID}/uploads`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/uploads`
 }
 
 /**
@@ -3704,7 +3704,7 @@ export const getCompleteUploadUrl = (driveID: string,
 
 
 
-  return `/v1/drives/${driveID}/uploads/${uploadId}/complete`
+  return `https://api.mdrive.mandacode.com/v1/drives/${driveID}/uploads/${uploadId}/complete`
 }
 
 /**
@@ -3831,7 +3831,7 @@ export const getPresignDownloadUrl = (driveID: string,
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/v1/drives/${driveID}/downloads?${stringifiedParams}` : `/v1/drives/${driveID}/downloads`
+  return stringifiedParams.length > 0 ? `https://api.mdrive.mandacode.com/v1/drives/${driveID}/downloads?${stringifiedParams}` : `https://api.mdrive.mandacode.com/v1/drives/${driveID}/downloads`
 }
 
 /**
@@ -3864,7 +3864,7 @@ export const presignDownload = async (driveID: string,
 export const getPresignDownloadQueryKey = (driveID: string,
     params?: PresignDownloadParams,) => {
     return [
-    `/v1/drives/${driveID}/downloads`, ...(params ? [params] : [])
+    `https://api.mdrive.mandacode.com/v1/drives/${driveID}/downloads`, ...(params ? [params] : [])
     ] as const;
     }
 
@@ -3976,7 +3976,7 @@ export const getGetUserUrl = () => {
 
 
 
-  return `/v1/users`
+  return `https://api.mdrive.mandacode.com/v1/users`
 }
 
 /**
@@ -4007,7 +4007,7 @@ export const getUser = async ( options?: RequestInit): Promise<getUserResponse> 
 
 export const getGetUserQueryKey = () => {
     return [
-    `/v1/users`
+    `https://api.mdrive.mandacode.com/v1/users`
     ] as const;
     }
 
@@ -4114,7 +4114,7 @@ export const getUpsertUserUrl = () => {
 
 
 
-  return `/v1/users`
+  return `https://api.mdrive.mandacode.com/v1/users`
 }
 
 /**
@@ -4209,7 +4209,7 @@ export const getAuthLoginUrl = () => {
 
 
 
-  return `/auth/login`
+  return `https://api.mdrive.mandacode.com/auth/login`
 }
 
 /**
@@ -4243,7 +4243,7 @@ export const authLogin = async ( options?: RequestInit): Promise<authLoginRespon
 
 export const getAuthLoginQueryKey = () => {
     return [
-    `/auth/login`
+    `https://api.mdrive.mandacode.com/auth/login`
     ] as const;
     }
 
@@ -4345,7 +4345,7 @@ export const getAuthCallbackUrl = (params: AuthCallbackParams,) => {
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/auth/callback?${stringifiedParams}` : `/auth/callback`
+  return stringifiedParams.length > 0 ? `https://api.mdrive.mandacode.com/auth/callback?${stringifiedParams}` : `https://api.mdrive.mandacode.com/auth/callback`
 }
 
 /**
@@ -4380,7 +4380,7 @@ export const authCallback = async (params: AuthCallbackParams, options?: Request
 
 export const getAuthCallbackQueryKey = (params?: AuthCallbackParams,) => {
     return [
-    `/auth/callback`, ...(params ? [params] : [])
+    `https://api.mdrive.mandacode.com/auth/callback`, ...(params ? [params] : [])
     ] as const;
     }
 
@@ -4475,7 +4475,7 @@ export const getAuthLogoutUrl = () => {
 
 
 
-  return `/auth/logout`
+  return `https://api.mdrive.mandacode.com/auth/logout`
 }
 
 /**
@@ -4579,7 +4579,7 @@ export const getAuthMeUrl = () => {
 
 
 
-  return `/auth/me`
+  return `https://api.mdrive.mandacode.com/auth/me`
 }
 
 /**
@@ -4610,7 +4610,7 @@ export const authMe = async ( options?: RequestInit): Promise<authMeResponse> =>
 
 export const getAuthMeQueryKey = () => {
     return [
-    `/auth/me`
+    `https://api.mdrive.mandacode.com/auth/me`
     ] as const;
     }
 

--- a/src/api/hooks/use-auth.ts
+++ b/src/api/hooks/use-auth.ts
@@ -9,13 +9,8 @@ import {
   getRestoreDriveMutationOptions,
 } from "@/api/generated";
 
-// Auth flow hits the API origin directly so Set-Cookie's Domain matches
-// the response origin. NEXT_PUBLIC_API_BASE is the API origin
-// (e.g. https://api.mdrive.mandacode.com); in dev it's empty so the
-// relative path goes to MSW.
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
-const authUrl = (path: string) =>
-  API_BASE ? `${API_BASE}${path}` : path;
+const API_BASE = "https://api.mdrive.mandacode.com";
+const authUrl = (path: string) => `${API_BASE}${path}`;
 
 export function useMe() {
   return useQuery({

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect } from "react";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
+const API_BASE = "https://api.mdrive.mandacode.com";
 
 export default function LoginPage() {
   useEffect(() => {
-    const url = new URL(API_BASE ? `${API_BASE}/auth/login` : "/auth/login");
+    const url = new URL(`${API_BASE}/auth/login`);
     url.searchParams.set(
       "redirect_uri",
       new URL("/", window.location.origin).toString()
@@ -20,4 +20,3 @@ export default function LoginPage() {
     </div>
   );
 }
-

--- a/src/lib/fetch-credentials.ts
+++ b/src/lib/fetch-credentials.ts
@@ -1,10 +1,6 @@
 // Cross-origin direct API calls need credentials: 'include' for the
 // session cookie to flow. orval 8.15.0 doesn't expose a config hook
-// for this, so we wrap window.fetch once at app boot.
-//
-// Also defends against non-JSON responses (e.g. an HTML error page
-// from a misconfigured CORS preflight) reaching orval's generated
-// JSON.parse. The original response status is preserved.
+// for this, so we wrap window.fetch once at app boot. Idempotent.
 let installed = false;
 
 export function installFetchCredentials(): void {
@@ -13,18 +9,6 @@ export function installFetchCredentials(): void {
   installed = true;
 
   const original = window.fetch.bind(window);
-  window.fetch = async (input, init) => {
-    const res = await original(input, { ...init, credentials: "include" });
-    const contentType = res.headers.get("content-type") ?? "";
-    if (contentType.includes("json")) return res;
-    const text = await res.clone().text();
-    if (!text || (!text.startsWith("{") && !text.startsWith("["))) {
-      return new Response("{}", {
-        status: res.status,
-        statusText: res.statusText,
-        headers: res.headers,
-      });
-    }
-    return res;
-  };
+  window.fetch = (input, init) =>
+    original(input, { ...init, credentials: "include" });
 }


### PR DESCRIPTION
## Summary

PR #52 used `NEXT_PUBLIC_API_BASE` env var for the API origin.
That added unnecessary complexity — orval reads the env at build
time either way, and the dev/prod split is handled by MSW
interception (URL doesn't matter in dev), not by a different baseUrl.

Hardcode `https://api.mdrive.mandacode.com` and remove the env var
complexity. Generated code has the absolute URL inlined.

## Changes

- `orval.config.ts`: `baseUrl: "https://api.mdrive.mandacode.com"`
  directly. `process.env.NEXT_PUBLIC_API_BASE ?? ""` removed.
- `next.config.mjs`: `NEXT_PUBLIC_API_BASE` env removed.
- `use-auth.ts`: `const API_BASE = "https://api.mdrive.mandacode.com"` (no
  env, no read at runtime).
- `app/login/page.tsx`: same constant.
- `src/lib/fetch-credentials.ts`: reduced to the single responsibility
  of adding `credentials: 'include'`. The defensive `JSON.parse`
  body check is gone — the real fix for non-JSON responses is upstream
  (backend CORS / correct routing), not something to silently absorb
  in the SPA. TanStack Query's `onError` already surfaces failures.

```
src/lib/fetch-credentials.ts before (22 lines):
  - read body, check if JSON-shaped, replace with '{}' if not
src/lib/fetch-credentials.ts after (15 lines):
  - wrap window.fetch to add credentials: 'include' (idempotent)
```

## Effect

```
-19 net lines in fetch-credentials.ts
-1 env var in next.config.mjs
-1 env var read in orval.config.ts
-1 env var read in use-auth.ts
+hardcoded production URL in orval.config.ts
+hardcoded production URL in use-auth.ts
+hardcoded production URL in login/page.tsx
```

## Verification

```bash
npm run lint     # 57 files clean
npx tsc --noEmit # clean
npm run build    # clean
``"

Generated fetch calls (after regen):
```ts
export const getAuthMeUrl = () => {
  return "https://api.mdrive.mandacode.com/auth/me";
};
export const getListDrivesUrl = () => {
  return "https://api.mdrive.mandacode.com/v1/drives";
};
``"

## Out of scope (separate work)

- Vercel env: `NEXT_PUBLIC_API_BASE` can be removed from the project
  settings if it was added — no longer read.
- Backend CORS: still needed for cross-origin /auth/me, /v1/* etc.