### PR TITLE
fix(auth): invalidate drives query using the orval-generated key

### DIFF
--- a/src/api/hooks/use-auth.ts
+++ b/src/api/hooks/use-auth.ts
@@ -4,6 +4,7 @@ import type { User } from "@/api/generated/model";
 import {
   getAuthMeQueryOptions,
   getCreateDriveMutationOptions,
+  getListDrivesQueryKey,
   getListDrivesQueryOptions,
   getDeleteDriveMutationOptions,
   getRestoreDriveMutationOptions,
@@ -35,7 +36,7 @@ export function useCreateDrive() {
   return useMutation({
     ...getCreateDriveMutationOptions(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/v1/drives"] });
+      queryClient.invalidateQueries({ queryKey: getListDrivesQueryKey() });
     },
   });
 }
@@ -45,7 +46,7 @@ export function useDeleteDrive() {
   return useMutation({
     ...getDeleteDriveMutationOptions(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/v1/drives"] });
+      queryClient.invalidateQueries({ queryKey: getListDrivesQueryKey() });
     },
   });
 }
@@ -55,7 +56,7 @@ export function useRestoreDrive() {
   return useMutation({
     ...getRestoreDriveMutationOptions(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/v1/drives"] });
+      queryClient.invalidateQueries({ queryKey: getListDrivesQueryKey() });
     },
   });
 }


### PR DESCRIPTION
useCreateDrive, useDeleteDrive, and useRestoreDrive all hardcoded queryKey: ["/v1/drives"] in their onSuccess invalidate, but getListDrivesQueryKey() — the key TanStack Query actually used to register the list — returns
["https://api.mdrive.mandacode.com/v1/drives"]. The keys do not match, so the list cache is never marked stale after a mutation: the next render of useDrives reads the cached empty response and the UI looks like the create silently failed even though the server accepted the request.

Replace the literal with getListDrivesQueryKey() in all three hooks so the invalidate path always lines up with the registered list query, regardless of any future base-URL change in the orval-generated client.